### PR TITLE
gtk version dependency for gtk_show_uri_on_window

### DIFF
--- a/wscript
+++ b/wscript
@@ -43,7 +43,7 @@ WELCOME_SCREEN_NAME = "Nuvola Apps 3.1 Rolling Releases"
 
 TARGET_GLIB = "2.42"
 MIN_GLIB = "2.42.1"
-MIN_GTK = "3.14.5"
+MIN_GTK = "3.22.0"
 MIN_WEBKIT = "2.6.2"
 
 import subprocess


### PR DESCRIPTION
gtk_show_uri_on_window  seems to be added in gtk version 3.22 
please check https://github.com/GNOME/gtk/commit/c6416aec748da82de04deaf75f58639af5096b44#diff-ad43b20a360191535860df61340a8d68 as I am not sure if I understand that correctly

fixes the following build problem:
```nuvolaplayer/build/src/nuvolakit-runner/master/AppIndexWebView.c:413: undefined reference to `gtk_show_uri_on_window'
collect2: error: ld returned 1 exit status```